### PR TITLE
Initialize local variables to avoid data leak

### DIFF
--- a/libs/gui/IGraphicBufferProducer.cpp
+++ b/libs/gui/IGraphicBufferProducer.cpp
@@ -231,7 +231,7 @@ status_t BnGraphicBufferProducer::onTransact(
             uint32_t h      = data.readInt32();
             uint32_t format = data.readInt32();
             uint32_t usage  = data.readInt32();
-            int buf;
+            int buf = 0;
             sp<Fence> fence;
             int result = dequeueBuffer(&buf, &fence, async, w, h, format, usage);
             reply->writeInt32(buf);
@@ -263,7 +263,7 @@ status_t BnGraphicBufferProducer::onTransact(
         } break;
         case QUERY: {
             CHECK_INTERFACE(IGraphicBufferProducer, data, reply);
-            int value;
+            int value = 0;
             int what = data.readInt32();
             int res = query(what, &value);
             reply->writeInt32(value);


### PR DESCRIPTION
The uninitialized local variables pick up
whatever the memory content was there on stack.
This data gets sent to the remote process in
case of a failed transaction, which is a security
issue. Fixed.

(Manual merge of master change
 12ba0f57d028a9c8f4eb3afddc326b70677d1e0c )

For b/23696300

Change-Id: I665212d10da56f0803b5bb772d14c77e632ba2ab
(cherry picked from commit c1e6fbb52c3f85cc7610d1d07d12be38f70b4ed4)
